### PR TITLE
fix: remove regression:true from mllib

### DIFF
--- a/src/components/widgets/Imaginate/connectors/commons/Description/index.test.js
+++ b/src/components/widgets/Imaginate/connectors/commons/Description/index.test.js
@@ -6,6 +6,42 @@ import _superagent from "superagent";
 
 import Description from './index'
 
+test('render category description from regression result', async () => {
+
+    const superagent = superagentPromise(_superagent, global.Promise);
+    const jsonUrl = '/mocks-dd-results-regression.json';
+    const json = await superagent
+      .get(jsonUrl)
+      .then(res => res.body)
+
+    const { container } = render(
+        <Description
+          imaginateStore={{
+             service: {
+                 selectedInput: {
+                     json: json
+                 }
+             }
+          }}
+        />
+    )
+
+    const descriptionElement = container.getElementsByClassName('description-category')[0];
+    expect(descriptionElement).toBeInTheDocument();
+
+    const badgeElement = descriptionElement.getElementsByClassName('badge')[0];
+    expect(badgeElement).toBeInTheDocument();
+
+    const regression_service = json.body.predictions[0];
+
+    // For regression services, containing vector array in prediction results,
+    // displayed value should be prediction val with category as tooltip
+    expect(badgeElement.dataset.tip)
+        .toBe(regression_service.vector[0].cat)
+    expect(badgeElement.textContent)
+        .toBe(regression_service.vector[0].val.toFixed(2))
+})
+
 test('render category description from regression chain result', async () => {
 
     const superagent = superagentPromise(_superagent, global.Promise);

--- a/src/stores/deepdetect/service.js
+++ b/src/stores/deepdetect/service.js
@@ -567,10 +567,13 @@ export default class deepdetectService {
         break;
 
       case "regression":
+
         delete input.postData.parameters.output.bbox;
         delete input.postData.parameters.output.confidence_threshold;
+        delete input.postData.parameters.mllib.regression;
+
         input.postData.parameters.output.regression = true;
-        input.postData.parameters.mllib.regression = true;
+
         break;
 
       default:


### PR DESCRIPTION
Remove `mllib.regression:true` from predict request on regression
service.

Add test on Imaginate Description component to ensure it renders a
ctegory description on regression service results.