### PR TITLE
fix: version file copied to nginx docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN yarn build
 RUN git describe --tags --dirty > /version
 
 FROM nginx:alpine
-COPY --from=builder /version /version
 COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /version /usr/share/nginx/html/version


### PR DESCRIPTION
version file must be served by platform_ui nginx image which has its default root configured at /usr/share/nginx/html/