### PR TITLE
fix: /version is created in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,8 @@
 # DeepDetect Platform UI (Changelog)
 
-### [0.13.5](https://github.com/jolibrain/platform_ui/compare/v0.13.3...v0.13.5) (2021-02-12)
-
-
-### Features
-
-* add isTimeSeries on model repositories ([4cf290c](https://github.com/jolibrain/platform_ui/commit/4cf290c03b9e700677fd212fa2177aa1dd5c14d7))
-* add L1 and L2 mean error chart on timeseries ([fc49e30](https://github.com/jolibrain/platform_ui/commit/fc49e30fc24ce6f637246200d3651b2c9a82a855))
-* TrainingShow title is parameterized ([2adc1a4](https://github.com/jolibrain/platform_ui/commit/2adc1a40b3cd4c4cd1e3fa91aa8d96f36e69c419))
+### [0.13.6](https://github.com/jolibrain/platform_ui/compare/v0.13.5...v0.13.6) (2021-02-12)
 
 
 ### Bug Fixes
 
-* add float formatter on modelRepository columns ([1fcfdf0](https://github.com/jolibrain/platform_ui/commit/1fcfdf0b572dd20ce054083e9030e8b17c9fa294))
-* buildInfoStore is not updatable by default ([2405057](https://github.com/jolibrain/platform_ui/commit/24050575a6632627408ac92a5e1236c630cf96c4))
-* compare major when comparing path ([b331b93](https://github.com/jolibrain/platform_ui/commit/b331b93716e0aba479becf0f9ff428ee385dcee9))
-* default version is "dev" ([80c6039](https://github.com/jolibrain/platform_ui/commit/80c6039a23356abe1a924976911aa1354d7d13f4))
-* formatting tabs ([6016671](https://github.com/jolibrain/platform_ui/commit/60166716c2f29a59c3148381c69e3470775ec958))
-* ignore public/version dev file ([6046945](https://github.com/jolibrain/platform_ui/commit/6046945df8e6f3099a3523eaf4c2da5dbcf4ef2f))
-* only update version when content available ([efd545d](https://github.com/jolibrain/platform_ui/commit/efd545df079d115d72694dacbc363e9b61af4412))
-* read platform_ui version from .env file ([629969f](https://github.com/jolibrain/platform_ui/commit/629969f97b161ac784206c6de376260ae30fa713))
-* remove mean iou graph on timeseries ([2d8c76f](https://github.com/jolibrain/platform_ui/commit/2d8c76f8ff57a722104c5409828255dfa2d5ac87))
-* review version display in AboutDropdown ([b991dad](https://github.com/jolibrain/platform_ui/commit/b991dad854858821a8cf0e7d2c3953209a3b9601))
+* /version is created in Dockerfile ([6eb91e9](https://github.com/jolibrain/platform_ui/commit/6eb91e9d69ce2117e9dc181b715ca95a6bd43301))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-ui",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-ui",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "description": "DeepDetect Platform UI",
   "dependencies": {

--- a/src/agent.js
+++ b/src/agent.js
@@ -45,7 +45,7 @@ const BuildInfo = {
       .end(handleErrors)
       .then(res => {
         let version = null;
-        const versionRegex = /^DD_PLATFORM_UI_TAG=(.*)$/m;
+        const versionRegex = /^(v\d+\.\d+\.\d+).*$/;
         if (
           res &&
             res.text &&


### PR DESCRIPTION
agent.js should parse the /version created from git tag in Dockerfile