### PR TITLE
Fix video explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ test/codecept/output/
 
 public/auth.json
 public/version
+public/config.json.backup*
 
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postcss-normalize": "8.0.1",
     "postcss-preset-env": "6.7.0",
     "postcss-safe-parser": "4.0.1",
-    "rc-slider": "^9.3.1",
+    "rc-slider": "^9.7.2",
     "react": "^16.13.1",
     "react-app-polyfill": "^1.0.6",
     "react-bootstrap": "^1.3.0",

--- a/src/agent.js
+++ b/src/agent.js
@@ -254,7 +254,7 @@ const Webserver = {
       .withCredentials()
       .catch(handleErrors)
       .then(res => {
-        console.log(res);
+        // console.log(res);
       })
   },
   writePathContent: async (path, content, loginAccess = {
@@ -290,7 +290,7 @@ const Webserver = {
       .withCredentials()
       .catch(handleErrors)
       .then(res => {
-        console.log(res);
+        // console.log(res);
       })
   },
   getFile: path =>

--- a/src/agent.js
+++ b/src/agent.js
@@ -257,6 +257,42 @@ const Webserver = {
         console.log(res);
       })
   },
+  writePathContent: async (path, content, loginAccess = {
+    url: "/filebrowser/api/login",
+    username: "",
+    password: ""
+  }) => {
+
+    let token = null;
+
+    if (
+      loginAccess &&
+        typeof loginAccess.url      !== "undefined" &&
+        typeof loginAccess.username !== "undefined" &&
+        typeof loginAccess.password !== "undefined"
+    )  {
+
+      const res = await superagent
+            .post(loginAccess.url)
+            .send({username: loginAccess.username})
+            .send({password: loginAccess.password})
+
+      if (res.status === 200) {
+        token = res.text;
+      }
+
+    }
+
+    superagent
+      .post(`${path}?override=false`)
+      .send(content)
+      .set('X-Auth', token)
+      .withCredentials()
+      .catch(handleErrors)
+      .then(res => {
+        console.log(res);
+      })
+  },
   getFile: path =>
     superagent
       .get(URL_JSON_PREFIX + path)

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -34,7 +34,7 @@ class Header extends React.Component {
     if (!configStore.isComponentBlacklisted("HeaderTitle")) {
       titleContent = (
         <Link to="/">
-          <img src="/logo.svg" alt="DeepDetect" />
+          <img src="/logo.svg" alt="DeepDetect" style={{height: 26}}/>
         </Link>
       )
     }

--- a/src/components/Header/links/Menus/Menu.js
+++ b/src/components/Header/links/Menus/Menu.js
@@ -1,6 +1,8 @@
 /* eslint jsx-a11y/anchor-is-valid: "off" */
 import React from "react";
+
 import MenuItem from "./MenuItem";
+import MenuDropdown from "./MenuDropdown";
 
 class Menu extends React.Component {
   constructor(props) {
@@ -61,6 +63,9 @@ class Menu extends React.Component {
           </a>
           <div className={`dropdown-menu ${this.state.menuDown ? "show" : ""}`}>
             {items.map((item, index) => (
+              typeof item.urls !== 'undefined' && item.urls.length > 0 ?
+              <MenuDropdown key={index} isDropdownItem={true} {...item} />
+                :
               <MenuItem key={index} isDropdownItem={true} {...item} />
             ))}
           </div>

--- a/src/components/Header/links/Menus/MenuDropdown.js
+++ b/src/components/Header/links/Menus/MenuDropdown.js
@@ -1,0 +1,109 @@
+/* eslint jsx-a11y/anchor-is-valid: "off" */
+import React from "react";
+
+class MenuDropdown extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      listDown: false
+    };
+
+    this.handleListClick = this.handleListClick.bind(this);
+
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener("mousedown", this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("mousedown", this.handleClickOutside);
+  }
+
+  /**
+   * Set the wrapper ref
+   */
+  setWrapperRef(node) {
+    this.wrapperRef = node;
+  }
+
+  handleClickOutside(event) {
+    if (
+      this.wrapperRef &&
+      !this.wrapperRef.contains(event.target) &&
+      this.state.listDown
+    ) {
+      this.setState({ listDown: false });
+    }
+  }
+
+  handleListClick() {
+    this.setState({ listDown: !this.state.listDown });
+  }
+
+
+  render() {
+    const { name, icon, urls } = this.props;
+
+    return (
+        <div
+          className="navbar-item menus-dropdown"
+          ref={this.setWrapperRef}
+        >
+          <a
+            className="nav-link dropdown-toggle"
+            style={{ cursor: "pointer" }}
+            id="navbarDropdown"
+            role="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+            onClick={this.handleListClick}
+          >
+            {typeof icon !== "undefined" ? (
+            <span>
+                <i className={icon} />
+                &nbsp;
+            </span>
+            ) : (
+            ""
+            )}
+            {name}
+          </a>
+          <div
+            className={`dropdown-menu ${this.state.listDown ? "show" : ""}`}
+            aria-labelledby="navbarDropdown"
+            style={{right: "auto"}}
+          >
+            { urls.map(item => {
+                return (
+                    <a
+                      key={`dropdown-menu-${item.title}`}
+                      className="dropdown-item"
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {typeof item.icon !== "undefined" ? (
+                          <span>
+                            <i className={item.icon} />
+                            &nbsp;
+                          </span>
+                      ) : (
+                          ""
+                      )}
+                      {item.title}
+                    </a>
+                )
+            }) }
+          </div>
+        </div>
+    );
+  }
+}
+
+export default MenuDropdown;

--- a/src/components/Header/links/Menus/index.js
+++ b/src/components/Header/links/Menus/index.js
@@ -2,23 +2,23 @@ import React from "react";
 import { inject } from "mobx-react";
 
 import Menu from "./Menu";
+import MenuDropdown from "./MenuDropdown";
 
 @inject("configStore")
 class MenusLink extends React.Component {
   render() {
     const { configStore } = this.props;
-
-    if (
-      configStore.isComponentBlacklisted("MenusLink") ||
-      typeof configStore.homeComponent.headerLinks.linkMenus === "undefined" ||
-      configStore.homeComponent.headerLinks.linkMenus.length === 0
-    )
-      return null;
-
     const { linkMenus } = configStore.homeComponent.headerLinks;
 
     const Menus = linkMenus.map((menu, index) => {
-      return (
+      return menu.urls && menu.urls.length > 0 ?
+        (
+        <div key={index}>
+          <MenuDropdown {...menu} />
+        </div>
+      )
+      :
+        (
         <div key={index}>
           <Menu {...menu} />
         </div>

--- a/src/components/VideoExplorer/Home/MainView.js
+++ b/src/components/VideoExplorer/Home/MainView.js
@@ -190,13 +190,13 @@ class MainView extends React.Component {
                           href={`${selectedVideo.path}output.mp4`}
                           className="badge badge-secondary"
                         >
-                          <i className="fas fa-download" /> output.mp4
+                          <i className="fas fa-download" /> Original video
                         </a> &nbsp;
                         <a
                           href={`${selectedVideo.path}output_bbox.mp4`}
                           className="badge badge-secondary"
                         >
-                          <i className="fas fa-download" /> output_bbox.mp4
+                          <i className="fas fa-download" /> Video with bounding boxes
                         </a>
                       </p>
                     </div>
@@ -288,9 +288,7 @@ class MainView extends React.Component {
         <div className={mainClassNames.join(" ")}>
           <div className="container-fluid">
             <div className="content">
-
               <SourceFolderSelector/>
-
               <RightPanel />
             </div>
           </div>

--- a/src/components/VideoExplorer/Home/MainView.js
+++ b/src/components/VideoExplorer/Home/MainView.js
@@ -212,16 +212,18 @@ class MainView extends React.Component {
                       <p>
                         <a
                           href={`${selectedVideo.path}${selectedFrame.jsonFile}`}
+                          download={`${selectedVideo.name}_{selectedFrame.jsonFile}`}
                           className="badge badge-secondary"
                         >
-                          <i className="fas fa-download" /> {selectedFrame.jsonFile}
+                          <i className="fas fa-download" /> JSON
                         </a>
                         &nbsp;
                         <a
                           href={`${selectedVideo.path}${selectedFrame.jsonFile.replace('.json', '.png')}`}
+                          download={`${selectedVideo.name}_{selectedFrame.jsonFile.replace('.json', '.png')}`}
                           className="badge badge-secondary"
                         >
-                          <i className="fas fa-download" /> frame{String(selectedFrame.index).padStart(8, '0')}.png
+                          <i className="fas fa-download" /> Image
                         </a>
                       </p>
                       <SyntaxHighlighter

--- a/src/components/VideoExplorer/Home/MainView.js
+++ b/src/components/VideoExplorer/Home/MainView.js
@@ -188,12 +188,14 @@ class MainView extends React.Component {
                       <p>
                         <a
                           href={`${selectedVideo.path}output.mp4`}
+                          download={`${selectedVideo.name}.mp4`}
                           className="badge badge-secondary"
                         >
                           <i className="fas fa-download" /> Original video
                         </a> &nbsp;
                         <a
                           href={`${selectedVideo.path}output_bbox.mp4`}
+                          download={`${selectedVideo.name}_bbox.mp4`}
                           className="badge badge-secondary"
                         >
                           <i className="fas fa-download" /> Video with bounding boxes

--- a/src/components/widgets/MainViewServiceList/Table/ModelRepository.js
+++ b/src/components/widgets/MainViewServiceList/Table/ModelRepository.js
@@ -134,7 +134,6 @@ class ModelRepositoryItem extends React.Component {
               <a
                 onClick={this.openPublishTrainingModal}
                 className="btn btn-outline-secondary"
-                href="#"
                 title="Publish"
               >
                 <i className="fas fa-plus" />
@@ -153,7 +152,6 @@ class ModelRepositoryItem extends React.Component {
               <a
                 onClick={this.deleteRepositoryModal}
                 className="btn btn-outline-danger"
-                href="#"
                 title="Delete"
               >
                 <i className="fas fa-trash" />

--- a/src/components/widgets/MainViewServiceList/Table/ModelRepository.js
+++ b/src/components/widgets/MainViewServiceList/Table/ModelRepository.js
@@ -46,16 +46,16 @@ class ModelRepositoryItem extends React.Component {
   }
 
   openPublishTrainingModal() {
-    const { modalStore } = this.props;
+    const { modalStore, service } = this.props;
     modalStore.setVisible("publishTraining", true, {
-      service: this.props.service
+      service: service
     });
   }
 
   deleteRepositoryModal() {
-    const { modalStore } = this.props;
+    const { modalStore, service } = this.props;
     modalStore.setVisible("deleteRepository", true, {
-      service: this.props.service
+      service: service
     });
   }
 

--- a/src/components/widgets/VideoExplorer/Frame/index.js
+++ b/src/components/widgets/VideoExplorer/Frame/index.js
@@ -30,6 +30,7 @@ class Frame extends React.Component {
         switch(subtitle.format){
             case 'leftRightPercentArray':
               value = value
+                .sort((a, b) => a - b)
                 .map(v => {
                   return `${v > 0 ? 'right' : 'left'}: ${Math.abs(parseInt(v * 100))}/100`;
                 })

--- a/src/components/widgets/VideoExplorer/Frame/index.js
+++ b/src/components/widgets/VideoExplorer/Frame/index.js
@@ -28,9 +28,11 @@ class Frame extends React.Component {
         const separator = subtitle.separator || " - ";
 
         switch(subtitle.format){
-            case 'percentArray':
+            case 'leftRightPercentArray':
               value = value
-                .map(v => `${Math.abs(parseInt(v * 100))}%`)
+                .map(v => {
+                  return `${v > 0 ? 'right' : 'left'}: ${Math.abs(parseInt(v * 100))}/100`;
+                })
                 .join(separator)
               break;
             default:

--- a/src/components/widgets/VideoExplorer/Frame/index.js
+++ b/src/components/widgets/VideoExplorer/Frame/index.js
@@ -25,6 +25,16 @@ class Frame extends React.Component {
       subtitles = cardSubtitle.map(subtitle => {
         let value = frame.stats[subtitle.statsKey];
 
+        let label = '';
+
+        if(showLabel) {
+          label = subtitle.label
+
+          if(Array.isArray(frame.stats[subtitle.statsKey])) {
+            label += ` (${frame.stats[subtitle.statsKey].length})`
+          }
+        }
+
         const separator = subtitle.separator || " - ";
 
         switch(subtitle.format){
@@ -40,7 +50,7 @@ class Frame extends React.Component {
               break;
         }
 
-        return value ? `${showLabel ? subtitle.label : ''} ${value}` : ''
+        return value ? `${label}: ${value}` : ''
       })
 
     } else {

--- a/src/components/widgets/VideoExplorer/Frame/index.js
+++ b/src/components/widgets/VideoExplorer/Frame/index.js
@@ -85,7 +85,7 @@ class Frame extends React.Component {
       >
         <div className="marker"/>
         <div className="timeline-content">
-          <h1>{title}</h1>
+          <h1>{title} - Frame {frame.index}</h1>
           {
             subtitle.map((v, index) => <h2 key={index}>{v}</h2>)
           }

--- a/src/components/widgets/VideoExplorer/Frame/index.js
+++ b/src/components/widgets/VideoExplorer/Frame/index.js
@@ -29,7 +29,7 @@ class Frame extends React.Component {
 
         switch(subtitle.format){
             case 'leftRightPercentArray':
-              value = value
+            value = value.slice()
                 .sort((a, b) => a - b)
                 .map(v => {
                   return `${v > 0 ? 'right' : 'left'}: ${Math.abs(parseInt(v * 100))}/100`;

--- a/src/stores/videoExplorerStore.js
+++ b/src/stores/videoExplorerStore.js
@@ -2,6 +2,7 @@ import { observable, action, computed } from "mobx";
 import agent from "../agent";
 import path from "path";
 import { nanoid } from 'nanoid';
+import moment from 'moment';
 
 export class videoExplorerStore {
     @observable loaded = false;
@@ -42,6 +43,11 @@ export class videoExplorerStore {
     @computed
     get outputFolderPath() {
         return path.join(this.settings.rootPath, this.settings.folders.output)
+    }
+
+    @computed
+    get feedbacksFolderPath() {
+        return path.join(this.settings.rootPath, this.settings.folders.feedbacks)
     }
 
     @computed
@@ -194,6 +200,40 @@ export class videoExplorerStore {
                     //console.log(e);
                 });
         });
+    }
+
+    @action
+    writeFeedback(feedbackContent) {
+
+        // Check if feedbackPath is set
+        if(
+            !this.settings &&
+                !this.settings.feedbackPath
+        )
+            return false;
+
+        const timestamp = moment().unix();
+
+        let feedbackFilename =
+            `${this.selectedVideo.name.replace(/\s+/gi, '_')}_`;
+
+        feedbackFilename += this.selectedFrame ?
+            `frame${this.selectedFrame.index}_` : ''
+
+        feedbackFilename += `${timestamp}.json`
+
+        const feedbackPath = path.join(
+            '/filebrowser/api/resources',
+            this.settings.feedbackPath,
+            feedbackFilename
+        );
+
+        console.log(feedbackPath)
+
+        return agent.Webserver.writePathContent(
+            feedbackPath,
+            `{"content": "${feedbackContent}", "timestamp": ${timestamp}}`
+        )
     }
 }
 

--- a/src/stores/videoExplorerStore.js
+++ b/src/stores/videoExplorerStore.js
@@ -99,7 +99,12 @@ export class videoExplorerStore {
     @action
     setFrameIndex(frameIndex) {
         this.frames.forEach(f => f.isSelected = false)
-        this.frames[frameIndex].isSelected = true
+
+        if(frameIndex >= this.frames.length)
+            frameIndex = this.frames.length - 1;
+
+        if(this.frames[frameIndex])
+            this.frames[frameIndex].isSelected = true
     }
 
     @action

--- a/src/stores/videoExplorerStore.js
+++ b/src/stores/videoExplorerStore.js
@@ -228,8 +228,6 @@ export class videoExplorerStore {
             feedbackFilename
         );
 
-        console.log(feedbackPath)
-
         return agent.Webserver.writePathContent(
             feedbackPath,
             `{"content": "${feedbackContent}", "timestamp": ${timestamp}}`

--- a/src/styles/commons/Header.scss
+++ b/src/styles/commons/Header.scss
@@ -158,6 +158,7 @@
     }
   }
 
+  .menus-dropdown,
   #servers-dropdown {
     i {
       color: $neutral_blue_9;

--- a/src/styles/widgets/VideoExplorer/styles.scss
+++ b/src/styles/widgets/VideoExplorer/styles.scss
@@ -1,3 +1,7 @@
+#autoScrollToggle > legend {
+  font-size: unset;
+}
+
 .source-folder-selector {
   margin-top: 50px;
   margin-right: auto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,6 +1124,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -10014,51 +10021,59 @@ rc-align@^4.0.0:
     rc-util "^5.0.1"
     resize-observer-polyfill "^1.5.1"
 
-rc-motion@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-1.1.2.tgz#07212f1b96c715b8245ec121339146c4a9b0968c"
-  integrity sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==
+rc-motion@^2.0.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.4.3.tgz#2afd129da8764ee0372ba83442949d8ecb1c7ad2"
+  integrity sha512-GZLLFXHl/VqTfI7bSZNNZozcblNmDka1AAoQig7EZ6s0rWg5y0RlgrcHWO+W+nrOVbYfJDxoaQUoP2fEmvCWmA==
   dependencies:
     "@babel/runtime" "^7.11.1"
     classnames "^2.2.1"
-    raf "^3.4.1"
-    rc-util "^5.0.6"
+    rc-util "^5.2.1"
 
-rc-slider@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-9.3.1.tgz#444012f3b4847d592b167a9cee6a1a46779a6ef4"
-  integrity sha512-c52PWPyrfJWh28K6dixAm0906L3/4MUIxqrNQA4TLnC/Z+cBNycWJUZoJerpwSOE1HdM3XDwixCsmtFc/7aWlQ==
+rc-slider@^9.7.2:
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-9.7.2.tgz#282f571f7582752ebaa33964e441184f4e79ad74"
+  integrity sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.5"
-    rc-tooltip "^4.0.0"
+    rc-tooltip "^5.0.1"
     rc-util "^5.0.0"
     shallowequal "^1.1.0"
 
-rc-tooltip@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-4.2.2.tgz#b0c374a26846f285b21eb74f9d533e6049e34b22"
-  integrity sha512-mAs+gAngUyHVA6HdFXsELoJOHgfjAACLLc8SGtnVhovJdyqs5ZGSL9p5i+ApNaVpwjswqShw7L4DRtMl7cXCQg==
+rc-tooltip@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.1.0.tgz#abb453c463c31a705aa01d268279f4ae6ae3b15f"
+  integrity sha512-pFqD1JZwNIpbdcefB7k5xREoHAWM/k3yQwYF0iminbmDXERgq4rvBfUwIvlCqqZSM7HDr9hYeYr6ZsVNaKtvCQ==
   dependencies:
-    rc-trigger "^4.2.1"
+    "@babel/runtime" "^7.11.2"
+    rc-trigger "^5.0.0"
 
-rc-trigger@^4.2.1:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-4.4.2.tgz#74f7ebcfdcdc191b7c82380def68fbba79ed5aec"
-  integrity sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==
+rc-trigger@^5.0.0:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.2.6.tgz#ae5f320a36400f9399ae571399d76326ce25ec09"
+  integrity sha512-XHsO7IBBDDIlBV++BTrmw2kCVNpNZQZCkT7d/edGWAsCxUTSYntw4gBXavicw/L0iT+rox8m5dgyZmMbmxoQJQ==
   dependencies:
-    "@babel/runtime" "^7.10.1"
+    "@babel/runtime" "^7.11.2"
     classnames "^2.2.6"
-    raf "^3.4.1"
     rc-align "^4.0.0"
-    rc-motion "^1.0.0"
-    rc-util "^5.0.1"
+    rc-motion "^2.0.0"
+    rc-util "^5.5.0"
 
-rc-util@^5.0.0, rc-util@^5.0.1, rc-util@^5.0.6:
+rc-util@^5.0.0, rc-util@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.2.1.tgz#c01a3e25b4d65570e433f46f85fdf36ed44de6af"
   integrity sha512-OnIKp4DsYZpT3St9LwiGARXyMR38wNbk7C4jXS6NGAGHZEQWck7W6qfiJwj+MUmhJiUisAknU6BUs65exbhFTw==
   dependencies:
+    react-is "^16.12.0"
+    shallowequal "^1.1.0"
+
+rc-util@^5.2.1, rc-util@^5.5.0:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.12.1.tgz#026e889546ad957bd8201512951923821f6dab63"
+  integrity sha512-PrvX/LUPONoeIaJ35hiS5SeXP6DhwAfpoJG6X4Kc5X7NDgCgk/NfXrNfmijuSh8suHkWk1Quz93d2JdjomwOQA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
     react-is "^16.12.0"
     shallowequal "^1.1.0"
 


### PR DESCRIPTION
First release of video-explorer component, it allows navigation of frame inside a targeted video.

`config.json` must to be completed with `videoExplorer` object as in the following example:

```
...
  "videoExplorer": {
    "icon": "fa-photo-video",
    "title": "Video Explorer",
    "rootPath": "/data/video_detection",
    "folders": {
      "output": "output/",
      "processed": "processed/",
      "thumbs": "thumbs/",
      "bbox_images": "proc_frames/"
    },
    "feedbackPath": "/video_detection/feedbacks/",
    "boundingBoxes": true,
    "selectedFrameTitleAttributes": ["Classname"],
    "chronoItemSelectors": {
      "showLabel": true,
      "cardTitle": "Classname",
      "cardSubtitle": [
      ]
    }
  },
...
```