### PR TITLE
fix: display dd server error when publishing training models

### DIFF
--- a/src/components/widgets/modals/PublishTrainingModal.js
+++ b/src/components/widgets/modals/PublishTrainingModal.js
@@ -149,29 +149,50 @@ class PublishTrainingModal extends React.Component {
             });
           }
         } else {
-          modelRepositoriesStore.refresh();
-          if (this.state.deleteAfterPublish) {
-            // TODO add serviceName in ddServer.deleteService method
-            // to avoid using private request method
-            await ddServer.$reqDeleteService(serviceName);
+
+          if(
+            response &&
+              response.status &&
+              response.status.code &&
+              response.status.code !== 200
+            ) {
 
             this.setState({
               spinner: false,
               publishMessage: {
-                isError: false,
-                content: `Service is now available on Predict page.`
+                isError: true,
+                content: `${response.status.msg}: ${response.status.dd_msg}`
               }
             });
+
           } else {
-            this.setState({
-              spinner: false,
-              publishMessage: {
-                isError: false,
-                content: `Service has been published.`,
-                serviceName: serviceName
-              }
-            });
+
+            modelRepositoriesStore.refresh();
+            if (this.state.deleteAfterPublish) {
+              // TODO add serviceName in ddServer.deleteService method
+              // to avoid using private request method
+              await ddServer.$reqDeleteService(serviceName);
+
+              this.setState({
+                spinner: false,
+                publishMessage: {
+                  isError: false,
+                  content: `Service is now available on Predict page.`
+                }
+              });
+            } else {
+              this.setState({
+                spinner: false,
+                publishMessage: {
+                  isError: false,
+                  content: `Service has been published.`,
+                  serviceName: serviceName
+                }
+              });
+            }
+
           }
+
         }
       });
     }


### PR DESCRIPTION
when publishing a training model, dd server can return a http 200 json
message with the description of an error.

Fetch and display this error message.