### PR TITLE
fix: check service exists to include it in MeasureChart

### DIFF
--- a/src/components/widgets/TrainingMonitor/components/MeasureChart/index.js
+++ b/src/components/widgets/TrainingMonitor/components/MeasureChart/index.js
@@ -576,7 +576,7 @@ class MeasureChart extends React.Component {
       }
     };
 
-    const values = services.map((service, index) =>
+    const values = services.filter(s => s).map((service, index) =>
       this.getServiceValue(service, index, attribute, chartData)
     );
 


### PR DESCRIPTION
When service is toggled-off in multiple services training archive view,
it'd disappear from service list and need to be remove before getting
its value to display the chart.