### PR TITLE
Adding docker hub build push recipe

### DIFF
--- a/.github/workflows/push-dockerhub-tag.yml
+++ b/.github/workflows/push-dockerhub-tag.yml
@@ -1,0 +1,67 @@
+name: Build and push tagged release to Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v*.*'
+      - 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - uses: olegtarasov/get-tag@v2.1
+        id: tagName
+
+#        with:
+#          tagRegex: "foobar-(.*)"  # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.
+#          tagRegexGroup: 1 # Optional. Default is 1.
+
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: tag
+        run : echo ${{ github.event.release.tag_name }}
+
+      - name: Build and push tagged version
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: |
+            jolibrain/platform_ui:${{ steps.tagName.outputs.tag }}
+#          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        env:
+            SOURCE_NAME: ${{ steps.branch_name.outputs.SOURCE_NAME }}
+            SOURCE_BRANCH: ${{ steps.branch_name.outputs.SOURCE_BRANCH }}
+            SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+


### PR DESCRIPTION
Hope it helps!

Looks like v0.18.0 exists in this github repo but not on docker hub

```
ProBook-440-G7:~/deepdetect/code/cpu$ CURRENT_UID=$(id -u):$(id -g) MUID=$(id -u) docker-compose up -d
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.25.8) or chardet (2.3.0) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
Pulling platform_ui (jolibrain/platform_ui:v0.18.0)...
ERROR: manifest for jolibrain/platform_ui:v0.18.0 not found: manifest unknown: manifest unknown
dgtlmoon@dgtlmoon-HP-ProBook-440-G7:~/deepdetect/code/cpu$
```