### PR TITLE
fix: use pathFilterStore to keep selected filters

### DIFF
--- a/src/components/Training/Home/MainView.js
+++ b/src/components/Training/Home/MainView.js
@@ -10,6 +10,7 @@ import RightPanel from "../commons/RightPanel";
 @inject("modelRepositoriesStore")
 @inject("configStore")
 @inject("gpuStore")
+@inject("pathFilterStore")
 @withRouter
 @observer
 class MainView extends React.Component {
@@ -19,8 +20,7 @@ class MainView extends React.Component {
     this.state = {
       filterServiceName: "",
       selectedComparePath: [],
-      archiveLayout: "list",
-      filteredPath: []
+      archiveLayout: "list"
     };
 
     this.handleServiceFilter = this.handleServiceFilter.bind(this);
@@ -29,7 +29,6 @@ class MainView extends React.Component {
     this.handleClickRefreshArchive = this.handleClickRefreshArchive.bind(this);
 
     this.handleCompareStateChange = this.handleCompareStateChange.bind(this);
-    this.handlePathFilter = this.handlePathFilter.bind(this);
     this.removeFilteredPath = this.removeFilteredPath.bind(this);
 
     this.handleClickArchiveLayoutCard = this.handleClickArchiveLayoutCard.bind(this);
@@ -60,15 +59,6 @@ class MainView extends React.Component {
     this.setState({ selectedComparePath: selectedComparePath });
   }
 
-  handlePathFilter(filter) {
-
-    if(!this.state.filteredPath.includes(filter))
-      this.setState({
-        filteredPath: [...this.state.filteredPath, filter]
-      })
-
-  }
-
   removeFilteredPath(filter) {
     let newFilteredPath = [...this.state.filteredPath]
     newFilteredPath.splice(newFilteredPath.indexOf(filter), 1)
@@ -96,11 +86,15 @@ class MainView extends React.Component {
   }
 
   render() {
-    const { deepdetectStore, modelRepositoriesStore } = this.props;
+    const {
+      deepdetectStore,
+      modelRepositoriesStore,
+      pathFilterStore
+    } = this.props;
 
     if (!deepdetectStore.isReady) return null;
 
-    const { filterServiceName, filteredPath } = this.state;
+    const { filterServiceName } = this.state;
 
     const { trainingServices } = deepdetectStore;
     const displayedTrainingServices = trainingServices
@@ -136,8 +130,8 @@ class MainView extends React.Component {
         const filteredByServiceNameInput = filterServiceName.length === 0 ||
               r.name.includes(filterServiceName);
 
-        const filteredByPathTag = filteredPath.length === 0 ||
-              filteredPath.every(item => {
+        const filteredByPathTag = pathFilterStore.filters.length === 0 ||
+              pathFilterStore.filters.every(item => {
                 return r.path.split("/").includes(item);
               });
 
@@ -283,11 +277,14 @@ class MainView extends React.Component {
             <div className="archiveTrainingList archive">
               <div className="filterPath-list">
               {
-                filteredPath.map((item, i) => {
+                pathFilterStore.filters.map((item, i) => {
                   return <span
                            key={i}
                            className="badge badge-dark"
-                  onClick={this.removeFilteredPath.bind(this, item)}
+                           onClick={
+                             pathFilterStore
+                               .removePathFilter.bind(this, item)
+                           }
                          >
                     <i className="fas fa-times"></i> {item}
                   </span>
@@ -299,7 +296,6 @@ class MainView extends React.Component {
                 layout={this.state.archiveLayout}
                 services={displayedArchiveRepositories}
                 handleCompareStateChange={this.handleCompareStateChange}
-                handlePathFilter={this.handlePathFilter}
                 selectedComparePath={this.state.selectedComparePath}
               />
             </div>

--- a/src/components/widgets/MainViewServiceList/Table/index.js
+++ b/src/components/widgets/MainViewServiceList/Table/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { observer } from "mobx-react";
+import { inject, observer } from "mobx-react";
 import { withRouter } from "react-router-dom";
 import moment from "moment"
 import ReactPaginate from 'react-paginate';
@@ -10,6 +10,7 @@ import TrainingItem from "./Training";
 import ModelRepositoryItem from "./ModelRepository";
 import DatasetItem from "./Dataset";
 
+@inject("pathFilterStore")
 @withRouter
 @observer
 class Table extends React.Component {
@@ -305,13 +306,9 @@ class Table extends React.Component {
 
   handleFilterClick(event){
     const { pagination } = this.state;
-    const { handlePathFilter } = this.props;
+    const { pathFilterStore } = this.props;
 
-    // missing prop
-    if(!handlePathFilter)
-      return null;
-
-    handlePathFilter(event.target.innerHTML);
+    pathFilterStore.addPathFilter(event.target.innerHTML);
 
     this.setState({
       pagination: {
@@ -569,7 +566,6 @@ class Table extends React.Component {
 
 Table.propTypes = {
   services: PropTypes.array.isRequired,
-  handleCompareStateChange: PropTypes.func,
-  handlePathFilter: PropTypes.func,
+  handleCompareStateChange: PropTypes.func
 };
 export default Table;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import datasetStore from "./stores/datasetStore";
 import videoExplorerStore from "./stores/videoExplorerStore";
 import modalStore from "./stores/modalStore";
 import authTokenStore from "./stores/authTokenStore";
+import pathFilterStore from "./stores/pathFilterStore";
 
 const stores = {
   configStore,
@@ -35,7 +36,8 @@ const stores = {
   datasetStore,
   videoExplorerStore,
   modalStore,
-  authTokenStore
+  authTokenStore,
+  pathFilterStore
 };
 
 // For easier debugging

--- a/src/stores/pathFilterStore.js
+++ b/src/stores/pathFilterStore.js
@@ -1,0 +1,20 @@
+import { observable, action } from "mobx";
+
+export class pathFilterStore {
+    @observable filters = [];
+
+    @action
+    addPathFilter = path => {
+        if(!this.filters.includes(path))
+            this.filters = [...this.filters, path]
+    }
+
+    @action
+    removePathFilter = path => {
+        let newFilteredPath = [...this.filters]
+        newFilteredPath.splice(newFilteredPath.indexOf(path), 1)
+        this.filters = newFilteredPath
+    }
+}
+
+export default new pathFilterStore();


### PR DESCRIPTION
When changing of pages on platform_ui, path filtering is now saved in
order to find the same listing when going back to TrainingHome