### PR TITLE
fix: add toggle to create tensorrt service

### DIFF
--- a/src/components/widgets/modals/PredictAddServiceModal.js
+++ b/src/components/widgets/modals/PredictAddServiceModal.js
@@ -15,7 +15,8 @@ class PredictAddServiceModal extends React.Component {
       serviceName: "",
       gpuId: 0,
       addErrors: [],
-      mediaType: null
+      mediaType: null,
+      isTensorRt: false
     };
 
     this.validateBeforeSubmit = this.validateBeforeSubmit.bind(this);
@@ -25,6 +26,8 @@ class PredictAddServiceModal extends React.Component {
     this.handleServiceNameChange = this.handleServiceNameChange.bind(this);
     this.handleGpuIdChange = this.handleGpuIdChange.bind(this);
     this.handleMediaChange = this.handleMediaChange.bind(this);
+
+    this.handleTensorRtToggle = this.handleTensorRtToggle.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -53,6 +56,10 @@ class PredictAddServiceModal extends React.Component {
   handleCancel() {
     this.setState({ addErrors: [] });
     this.props.modalStore.setVisible("addService", false);
+  }
+
+  handleTensorRtToggle(event) {
+    this.setState({ isTensorRt: !event.target.value })
   }
 
   validateBeforeSubmit() {
@@ -98,6 +105,10 @@ class PredictAddServiceModal extends React.Component {
     this.setState({ spinner: true });
 
     let serviceData = repository.jsonConfig;
+
+    if(this.state.isTensorRt) {
+      serviceData.mllib = "tensorrt";
+    }
 
     if (serviceData.parameters.output) {
       serviceData.parameters.output.store_config = false;
@@ -199,6 +210,22 @@ class PredictAddServiceModal extends React.Component {
                 name of the Predict service, it must be unique.
               </small>
             </div>
+
+            <div className="form-group">
+              <input
+                type="checkbox"
+                defaultChecked={this.state.isTensorRt}
+                onChange={this.handleToggleTensorRt}
+              />{" "}
+              TensorRt Service
+              <small
+                id="tensorRtServiceHelp"
+                className="form-text text-muted"
+              >
+                If checked, service will be created with TensorRt mllib
+              </small>
+            </div>
+
             {gpuStoreServer && gpuStoreServer.gpuInfo ? (
               <div className="form-group">
                 <label>GPU Id</label>


### PR DESCRIPTION
When creating a new service from PredictHome, it's possible to set its
mllib as tensorrt.