### PR TITLE
fix: filter out sampling keys from measure_hist

### DIFF
--- a/src/components/widgets/TrainingMonitor/components/MeasureHistArray/index.js
+++ b/src/components/widgets/TrainingMonitor/components/MeasureHistArray/index.js
@@ -18,7 +18,11 @@ class MeasureHistArray extends React.Component {
     let measureHistKeys = service.measure_hist ?
         Object.keys(service.measure_hist)
               .sort()
-              .filter(k => k !== "iteration_hist" && k !== "train_loss_hist")
+              .filter(k => {
+                return k !== "iteration_hist" &&
+                  k !== "train_loss_hist" &&
+                  k.indexOf("_sampling") === -1
+              })
         : []; // check on service.measure_hist, empty array if undefined
 
     if (measureHistKeys.length === 0) return null;


### PR DESCRIPTION
Do not show measure keys containing `_sampling` in measure hist table
array.