### PR TITLE
fix: get latest docker tag from docker.jolibrain.com

### DIFF
--- a/src/components/Header/dropdowns/AboutDropdown.js
+++ b/src/components/Header/dropdowns/AboutDropdown.js
@@ -57,7 +57,7 @@ class AboutDropdown extends React.Component {
         <div className="dropdown-divider" />
         <a
           className="dropdown-item version-link"
-          href="https://docker.jolibrain.com/"
+          href="https://docker.jolibrain.com/#!/taglist/platform_ui"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/stores/buildInfoStore.js
+++ b/src/stores/buildInfoStore.js
@@ -1,6 +1,5 @@
 import { observable, action, computed } from "mobx";
 import agent from "../agent";
-import moment from "moment";
 
 export class buildInfoStore {
   @observable isReady = false;
@@ -90,12 +89,9 @@ export class buildInfoStore {
         this.latestDockerTag = dockerTags &&
           dockerTags.results &&
           dockerTags.results
-          .sort((a, b) => {
-            return moment(b.last_updated)
-              .diff(a.last_updated)
-          }).find(tag => {
-            return tag.name.match(/v\d+\.\d+\.\d+$/g)
-          }).name;
+          .find(tag => {
+            return tag.match(/v\d+\.\d+\.\d+$/g)
+          });
       })
     );
   }


### PR DESCRIPTION
Parse new tag format from docker.jolibrain.com in order to alert user if a new version is available for update.